### PR TITLE
[WIP] Implement separate module reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,8 @@ const SekshiModule = require('../Module')
 export default class MyModule extends SekshiModule {
   constructor(sekshi, options) {
     // meta
-    this.name = 'My Module'
     this.author = 'Me!'
-    this.version = '0.1.0'
+    this.version = '0.1.1'
     this.description = 'This is a module!'
 
     // initialise the module AFTER you've set meta data!
@@ -62,10 +61,14 @@ export default class MyModule extends SekshiModule {
       who: sekshi.USERROLE.NONE, // Anyone can use this command!
       why: sekshi.USERROLE.BOUNCER // Only bouncers and up can use this command!
     }
+  }
 
+  // init() will be run when the module is enabled:
+  init() {
     // your own initialisation! Maybe you want to add some event handlers, or start a timer…
   }
 
+  // and destroy() will be run when the module is disabled:
   destroy() {
     // detach any event listeners here, if you have them
   }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "sekshi",
   "description": "sekshi is a BOT system developed for We <3 KPOP",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "main": "lib/sekshi",
   "author": "Sooyou",
   "homepage": "xn--xck.moe",
   "dependencies": {
+    "array-find": "^0.1.1",
     "array-findindex": "^0.1.0",
     "babel": "^4.1.1",
     "debug": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sekshi",
   "description": "sekshi is a BOT system developed for We <3 KPOP",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "main": "lib/sekshi",
   "author": "Sooyou",
   "homepage": "xn--xck.moe",

--- a/src/Module.js
+++ b/src/Module.js
@@ -3,30 +3,33 @@ const assign = require('object-assign')
 export default class Module {
 
   constructor(sekshi, options = {}) {
-    if (typeof this.name !== 'string') {
-      throw new Error('Modules have to have a name')
-    }
-
     this.sekshi = sekshi
     this.options = assign({}, this.defaultOptions(), options)
     this.permissions = {}
 
-    this._enabled = true
+    this._enabled = false
   }
 
   defaultOptions() {
     return {}
   }
 
+  init() {
+  }
   destroy() {
   }
 
   enable() {
-    this._enabled = true
+    if (!this.enabled()) {
+      this._enabled = true
+      this.init()
+    }
   }
   disable() {
-    this.destroy()
-    this._enabled = false
+    if (this.enabled()) {
+      this.destroy()
+      this._enabled = false
+    }
   }
   enabled() {
     return this._enabled

--- a/src/modules/Disconnect.module.js
+++ b/src/modules/Disconnect.module.js
@@ -13,30 +13,32 @@ const Disconnections = mongoose.modelNames().indexOf('Disconnections') === -1
 
 export default class Disconnect extends SekshiModule {
   constructor(sekshi, options) {
-    this.name = 'Disconnect'
     this.author = 'Sooyou'
     this.version = '1.0.0'
-    this.description = 'Provides basic moderation tools'
+    this.description = 'Puts disconnected users back at their original wait list spot.'
 
     super(sekshi, options)
-
-    this.waitlist = []
-    this.dropped = []
 
     this.permissions = {
       dc: sekshi.USERROLE.NONE
     }
 
+    this.Disconnection = Disconnections
+
     this.onWaitlistUpdate = this.onWaitlistUpdate.bind(this)
     this.onUserLeave = this.onUserLeave.bind(this)
-    sekshi.on(sekshi.WAITLIST_UPDATE, this.onWaitlistUpdate)
-    sekshi.on(sekshi.USER_LEAVE, this.onUserLeave)
   }
 
   defaultOptions() {
     return {
       timeLimit: 10 * 60 // minutes
     }
+  }
+
+  init() {
+    this.waitlist = []
+    this.sekshi.on(this.sekshi.WAITLIST_UPDATE, this.onWaitlistUpdate)
+    this.sekshi.on(this.sekshi.USER_LEAVE, this.onUserLeave)
   }
 
   destroy() {

--- a/src/modules/Emotes.module.js
+++ b/src/modules/Emotes.module.js
@@ -15,7 +15,6 @@ const cleanId = id => id.toLowerCase()
 
 export default class Emotes extends SekshiModule {
   constructor(sekshi, options) {
-    this.name = 'Emotes'
     this.author = 'ReAnna'
     this.version = '1.0.0'
     this.description = 'adds several emoticons as well as gifs and webms'
@@ -30,6 +29,8 @@ export default class Emotes extends SekshiModule {
       emote: sekshi.USERROLE.NONE,
       e: sekshi.USERROLE.NONE
     }
+
+    this.Emote = Emote
   }
 
   sendEmote(msg, username) {

--- a/src/modules/Greetings.module.js
+++ b/src/modules/Greetings.module.js
@@ -1,30 +1,25 @@
 const debug = require('debug')('sekshi:greeting')
-const assign = require('object-assign')
 const SekshiModule = require('../Module')
 
 export default class Greetings extends SekshiModule {
 
   constructor(sekshi, options) {
-    this.name = 'Greetings'
     this.author = 'Sooyou'
     this.version = '0.1.0'
     this.description = 'Greets users.'
 
     super(sekshi, options)
+
     this.permissions = {
       greetusers: sekshi.USERROLE.BOUNCER
     }
 
-    this.autogreet = true
-    this.lastGreeted = -1
-
     this.greet = this.greet.bind(this)
-    sekshi.on(sekshi.USER_JOIN, this.greet)
-    sekshi.on(sekshi.FRIEND_JOIN, this.greet)
   }
 
   defaultOptions() {
     return {
+      autogreet: true,
       greetings: [
         'Hai @',
         'Welcome, @!',
@@ -32,8 +27,7 @@ export default class Greetings extends SekshiModule {
         'Heyho @',
         'Hej @',
         '안녕, @!',
-        'Hi @',
-        '/me hugs @'
+        'Hi @'
       ],
       emoji: [
         ':purple_heart:',
@@ -43,20 +37,25 @@ export default class Greetings extends SekshiModule {
     }
   }
 
+  init() {
+    this.lastGreeted = -1
+    this.sekshi.on(this.sekshi.USER_JOIN, this.greet)
+    this.sekshi.on(this.sekshi.FRIEND_JOIN, this.greet)
+  }
+
   destroy() {
     this.sekshi.removeListener(this.sekshi.USER_JOIN, this.greet)
     this.sekshi.removeListener(this.sekshi.FRIEND_JOIN, this.greet)
   }
 
   greetusers(toggle) {
-    this.autogreet = (toggle.toLowerCase() === 'true' ? true : false)
+    this.options.autogreet = (toggle.toLowerCase() === 'true' ? true : false)
   }
 
   greet(user) {
-    if (!this.autogreet ||
+    if (!this.options.autogreet ||
         this.lastGreeted == user.id ||
-        user.username === this.sekshi.getSelf().username ||
-        !this.sekshi.isModuleEnabled(this.name)) {
+        user.username === this.sekshi.getSelf().username) {
       return
     }
 

--- a/src/modules/HistoryLogger.module.js
+++ b/src/modules/HistoryLogger.module.js
@@ -1,5 +1,4 @@
 const debug = require('debug')('sekshi:history-logging')
-const assign = require('object-assign')
 const { User, Media, HistoryEntry } = require('../models')
 const Promise = require('promise')
 const SekshiModule = require('../Module')
@@ -7,18 +6,18 @@ const SekshiModule = require('../Module')
 export default class HistoryLogger extends SekshiModule {
 
   constructor(sekshi, options) {
-    this.name = 'History Logger'
     this.author = 'ReAnna'
     this.version = '0.3.0'
     this.description = 'Keeps a history of all songs that are played in the room.'
 
     super(sekshi, options)
 
-    // sigh…
     this.onAdvance = this.onAdvance.bind(this)
-    sekshi.on(sekshi.ADVANCE, this.onAdvance)
   }
 
+  init() {
+    this.sekshi.on(this.sekshi.ADVANCE, this.onAdvance)
+  }
   destroy() {
     this.sekshi.removeListener(this.sekshi.ADVANCE, this.onAdvance)
   }

--- a/src/modules/HistorySkip.module.js
+++ b/src/modules/HistorySkip.module.js
@@ -1,11 +1,9 @@
 const debug = require('debug')('sekshi:history-skip')
-const assign = require('object-assign')
 const SekshiModule = require('../Module')
 
 export default class HistorySkip extends SekshiModule {
 
   constructor(sekshi, options) {
-    this.name = 'HistorySkip'
     this.author = 'ReAnna'
     this.version = '0.1.0'
     this.description = 'Autoskip songs that have been played recently.'
@@ -15,7 +13,6 @@ export default class HistorySkip extends SekshiModule {
     this._skipping = false
 
     this.onAdvance = this.onAdvance.bind(this)
-    sekshi.on(sekshi.ADVANCE, this.onAdvance)
   }
 
   defaultOptions() {
@@ -24,6 +21,9 @@ export default class HistorySkip extends SekshiModule {
     }
   }
 
+  init() {
+    this.sekshi.on(this.sekshi.ADVANCE, this.onAdvance)
+  }
   destroy() {
     this.sekshi.removeListener(this.sekshi.ADVANCE, this.onAdvance)
   }

--- a/src/modules/Links.module.js
+++ b/src/modules/Links.module.js
@@ -4,7 +4,6 @@ const SekshiModule = require('../Module')
 export default class Links extends SekshiModule {
 
   constructor(sekshi, options) {
-    this.name = 'Links'
     this.author = 'ReAnna'
     this.version = '0.1.0'
     this.description = 'Throws links at people.'

--- a/src/modules/Misc.module.js
+++ b/src/modules/Misc.module.js
@@ -1,13 +1,13 @@
 const SekshiModule = require('../Module')
+const debug = require('debug')('sekshi:misc')
 const findIndex = require('array-findindex')
 
 export default class Misc extends SekshiModule {
 
   constructor(sekshi, options) {
-    this.name = 'Misc'
     this.author = 'Sooyou'
     this.version = '0.2.0'
-    this.description = 'Provides basic moderation tools'
+    this.description = 'Provides miscellaneous tools'
 
     super(sekshi, options)
 

--- a/src/modules/ModSkip.module.js
+++ b/src/modules/ModSkip.module.js
@@ -4,7 +4,6 @@ const SekshiModule = require('../Module')
 export default class ModSkip extends SekshiModule {
 
   constructor(sekshi, options) {
-    this.name = 'ModSkip'
     this.author = 'ReAnna'
     this.version = '0.2.0'
     this.description = 'Simple DJ skipping tools'

--- a/src/modules/RedditFeed.module.js
+++ b/src/modules/RedditFeed.module.js
@@ -6,7 +6,6 @@ const SekshiModule = require('../Module')
 export default class RedditFeed extends SekshiModule {
 
   constructor(sekshi, options) {
-    this.name = 'RedditFeed'
     this.author = 'schrobby'
     this.version = '0.3.0'
     this.description = 'Announces new submissions from a configurable list of subreddits.'
@@ -18,17 +17,10 @@ export default class RedditFeed extends SekshiModule {
       removesubreddit: sekshi.USERROLE.MANAGER,
       listsubreddits: sekshi.USERROLE.NONE,
       setfeedinterval: sekshi.USERROLE.COHOST,
-      updatereddit: sekshi.USERROLE.NONE
+      updatereddit: sekshi.USERROLE.MANAGER
     }
 
     this.reddit = new Snoocore({ userAgent: `RedditFeed v${this.version} by /u/schrobby` })
-    this.lastPost = ''
-    this.timer = setTimeout(this.runTimer.bind(this), 0)
-  }
-
-  updatereddit() {
-    clearTimeout(this.timer)
-    this.runTimer()
   }
 
   defaultOptions() {
@@ -39,11 +31,21 @@ export default class RedditFeed extends SekshiModule {
     }
   }
 
+  init() {
+    this.lastPost = ''
+    this.timer = setTimeout(this.runTimer.bind(this), 0)
+  }
+
   destroy() {
     if (this.timer) {
       clearTimeout(this.timer)
       this.timer = null
     }
+  }
+
+  updatereddit() {
+    clearTimeout(this.timer)
+    this.runTimer()
   }
 
   runTimer() {

--- a/src/modules/Roulette.module.js
+++ b/src/modules/Roulette.module.js
@@ -6,7 +6,6 @@ const moment = require('moment')
 export default class Roulette extends SekshiModule {
 
   constructor(sekshi, options) {
-    this.name = 'Roulette'
     this.author = 'ReAnna'
     this.version = '0.4.0'
     this.description = 'Runs random raffles for wait list position #1.'
@@ -18,9 +17,6 @@ export default class Roulette extends SekshiModule {
       players: sekshi.USERROLE.NONE,
       roulette: sekshi.USERROLE.MANAGER
     }
-
-    this._running = false
-    this._players = []
   }
 
   defaultOptions() {
@@ -28,6 +24,11 @@ export default class Roulette extends SekshiModule {
       duration: 120
     , minPosition: 6
     }
+  }
+
+  init() {
+    this._running = false
+    this._players = []
   }
 
   destroy() {

--- a/src/modules/SongLengthSkip.module.js
+++ b/src/modules/SongLengthSkip.module.js
@@ -5,23 +5,24 @@ const SekshiModule = require('../Module')
 export default class SongLengthSkip extends SekshiModule {
 
   constructor(sekshi, options = {}) {
-    this.name = 'Song Length Skip'
     this.author = 'ReAnna'
     this.version = '0.1.1'
     this.description = 'Autoskip songs that are too long.'
 
     super(sekshi, options)
 
-    this._skipping = false
-
     this.onAdvance = this.onAdvance.bind(this)
-    sekshi.on(sekshi.ADVANCE, this.onAdvance)
   }
 
   defaultOptions() {
     return {
       limit: 7 * 60
     }
+  }
+
+  init() {
+    this._skipping = false
+    this.sekshi.on(this.sekshi.ADVANCE, this.onAdvance)
   }
 
   destroy() {

--- a/src/modules/System.module.js
+++ b/src/modules/System.module.js
@@ -25,13 +25,16 @@ export default class System extends SekshiModule {
 
   reloadmodule(user, name) {
     this.sekshi.reloadModule(name)
+    this.sekshi.sendChat(`@${user.username} Reloaded module "${name}".`)
   }
 
   disablemodule(user, name) {
     this.sekshi.disable(name)
+    this.sekshi.sendChat(`@${user.username} Module "${name}" disabled.`)
   }
   enablemodule(user, name) {
     this.sekshi.enable(name)
+    this.sekshi.sendChat(`@${user.username} Module "${name}" enabled.`)
   }
 
   moduleinfo(user, name) {
@@ -56,6 +59,7 @@ export default class System extends SekshiModule {
 
   reloadmodules(user) {
     this.sekshi.reloadModules()
+    this.sekshi.sendChat(`@${user.username} Reloaded all modules.`)
   }
 
   listmodules(user) {

--- a/src/modules/System.module.js
+++ b/src/modules/System.module.js
@@ -4,7 +4,6 @@ const SekshiModule = require('../Module')
 export default class System extends SekshiModule {
 
   constructor(sekshi, options) {
-    this.name = 'System'
     this.author = 'Sooyou'
     this.version = '0.11.1'
     this.description = 'Simple tools for module management & system information'
@@ -13,44 +12,57 @@ export default class System extends SekshiModule {
 
     this.permissions = {
       sysinfo: sekshi.USERROLE.COHOST,
-      moduleinfo: sekshi.USERROLE.COHOST,
-      listmodules: sekshi.USERROLE.COHOST,
+      moduleinfo: sekshi.USERROLE.MANAGER,
+      listmodules: sekshi.USERROLE.MANAGER,
       togglemodule: sekshi.USERROLE.COHOST,
       reloadmodules: sekshi.USERROLE.COHOST,
+      reloadmodule: sekshi.USERROLE.MANAGER,
+      enablemodule: sekshi.USERROLE.MANAGER,
+      disablemodule: sekshi.USERROLE.MANAGER,
       exit: sekshi.USERROLE.MANAGER
     }
   }
 
-  moduleinfo(user, modulename) {
-    if(!modulename || modulename.length === 0) {
+  reloadmodule(user, name) {
+    this.sekshi.reloadModule(name)
+  }
+
+  disablemodule(user, name) {
+    this.sekshi.disable(name)
+  }
+  enablemodule(user, name) {
+    this.sekshi.enable(name)
+  }
+
+  moduleinfo(user, name) {
+    if(!name || name.length === 0) {
         this.sekshi.sendChat(`usage: !moduleinfo "modulename"`)
         return;
     }
 
-    const mod = this.sekshi.getModule(modulename)
+    const mod = this.sekshi.getModule(name)
     if (mod) {
       this.sekshi.sendChat(
-        `:${mod.enabled() ? 'small_blue_diamond' : 'small_red_triangle'}: Module info for "${mod.name}" ` +
+        `:${mod.enabled() ? 'small_blue_diamond' : 'small_red_triangle'}: Module info for "${name}" ` +
         `:white_small_square: Version: ${mod.version} ` +
         `:white_small_square: Author: ${mod.author} ` +
         `:white_small_square: Description: ${mod.description}`
       )
     }
     else {
-      this.sekshi.sendChat(`Module "${modulename}" does not exist.`);
+      this.sekshi.sendChat(`Module "${name}" does not exist.`);
     }
   }
 
   reloadmodules(user) {
-    this.sekshi.reloadmodules()
+    this.sekshi.reloadModules()
   }
 
   listmodules(user) {
-    let text = []
-    for (let name in this.sekshi.modules) if (this.sekshi.modules.hasOwnProperty(name)) {
-      let mod = this.sekshi.modules[name]
-      text.push(`${mod.name} ${mod.enabled() ? '✔' : '✘'}`)
-    }
+    const text = this.sekshi.getAvailableModules().map(name => {
+      const mod = this.sekshi.getModule(name)
+      return `${name} ${mod && mod.enabled() ? '✔' : '✘'}`
+    })
     this.sekshi.sendChat(text.sort().join(', '), 20 * 1000)
   }
 

--- a/src/modules/UserKarma.module.js
+++ b/src/modules/UserKarma.module.js
@@ -6,7 +6,6 @@ const SekshiModule = require('../Module')
 export default class UserKarma extends SekshiModule {
 
   constructor(sekshi, options) {
-    this.name = 'User Karma'
     this.author = 'brookiebeast'
     this.version = '0.1.0'
     this.description = 'Keeps track of users\' earned internet points.'

--- a/src/modules/UserLogger.module.js
+++ b/src/modules/UserLogger.module.js
@@ -6,18 +6,18 @@ const SekshiModule = require('../Module')
 export default class UserLogger extends SekshiModule {
 
   constructor(sekshi, options) {
-    this.name = 'User Logger'
     this.author = 'ReAnna'
     this.version = '0.1.0'
     this.description = 'Keeps track of users who visit the channel.'
 
     super(sekshi, options)
 
-    // sigh…
     this.onUserJoin = this.onUserJoin.bind(this)
-    sekshi.on(sekshi.USER_JOIN, this.onUserJoin)
   }
 
+  init() {
+    this.sekshi.on(this.sekshi.USER_JOIN, this.onUserJoin)
+  }
   destroy() {
     this.sekshi.removeListener(this.sekshi.USER_JOIN, this.onUserJoin)
   }

--- a/src/modules/VoteSkip.module.js
+++ b/src/modules/VoteSkip.module.js
@@ -5,19 +5,14 @@ const SekshiModule = require('../Module')
 export default class VoteSkip extends SekshiModule {
 
   constructor(sekshi, options) {
-    this.name = 'VoteSkip'
     this.author = 'ReAnna'
     this.version = '0.1.0'
     this.description = 'Autoskip songs after a number of mehs.'
 
     super(sekshi, options)
 
-    this._skipping = false
-
     this.onVote = this.onVote.bind(this)
     this.onAdvance = this.onAdvance.bind(this)
-    sekshi.on(sekshi.VOTE, this.onVote)
-    sekshi.on(sekshi.ADVANCE, this.onAdvance)
   }
 
   defaultOptions() {
@@ -26,6 +21,12 @@ export default class VoteSkip extends SekshiModule {
     }
   }
 
+  init() {
+    this._skipping = false
+
+    this.sekshi.on(this.sekshi.VOTE, this.onVote)
+    this.sekshi.on(this.sekshi.ADVANCE, this.onAdvance)
+  }
   destroy() {
     this.sekshi.removeListener(this.sekshi.VOTE, this.onVote)
     this.sekshi.removeListener(this.sekshi.ADVANCE, this.onAdvance)

--- a/src/sekshi.js
+++ b/src/sekshi.js
@@ -23,6 +23,7 @@ function Sekshi(args) {
     this.db = mongoose.connect(args.mongo);
 
     this.modules = {};
+    this._availableModules = []
     this.delimiter = args.delimiter || '!';
     this.modulePath = args.modulePath || path.join(__dirname, "modules");
 
@@ -209,9 +210,14 @@ Sekshi.prototype.getModuleFiles = function(modulePath) {
     return modules;
 };
 
-Sekshi.prototype.getAvailableModules = function () {
-    return this.getModuleFiles(this.modulePath)
+Sekshi.prototype.updateAvailableModules = function () {
+    debug('updateAvailableModules')
+    return this._availableModules = this.getModuleFiles(this.modulePath)
         .map(file => file.match(/\/([^\/]+?)\.module\.js$/)[1])
+}
+
+Sekshi.prototype.getAvailableModules = function () {
+    return this._availableModules
 }
 
 Sekshi.prototype.getModulePath = function (name) {
@@ -242,6 +248,7 @@ Sekshi.prototype.enable = function (name) {
 
 Sekshi.prototype.loadModules = function () {
     debug('load all')
+    this.updateAvailableModules()
     this.getAvailableModules().forEach(this._loadModule, this)
 }
 

--- a/src/sekshi.js
+++ b/src/sekshi.js
@@ -23,7 +23,6 @@ function Sekshi(args) {
     this.db = mongoose.connect(args.mongo);
 
     this.modules = {};
-    this.files = new Map()
     this.delimiter = args.delimiter || '!';
     this.modulePath = args.modulePath || path.join(__dirname, "modules");
 
@@ -231,13 +230,13 @@ Sekshi.prototype.disable = function (name) {
     if (mod) {
         mod.disable()
     }
-    this._unloadModule(name)
 }
 
 Sekshi.prototype.enable = function (name) {
     debug('enable', name)
-    if (this.moduleExists(name)) {
-        this._loadModule(name).enable()
+    const mod = this.getModule(name)
+    if (mod) {
+        mod.enable()
     }
 }
 
@@ -254,8 +253,19 @@ Sekshi.prototype.unloadModules = function() {
 }
 
 Sekshi.prototype.reloadModule = function (name) {
+    let mod = this.getModule(name)
+    let enabled = false
+    if (mod) {
+        enabled = mod.enabled()
+        mod = null
+    }
+
     this._unloadModule(name)
     this._loadModule(name)
+
+    if (enabled) {
+        this.getModule(name).enable()
+    }
 }
 
 Sekshi.prototype._loadModule = function (name) {


### PR DESCRIPTION
#5

SekshiBot now takes the module name from the file name, instead of from the class instance. Modules can be loaded/unloaded and enabled/disabled individually, on the fly.

Event handlers should be attached in the new init() hook on modules. This will be called when the module is enabled.

Adds commands for enabling/disabling and reloading modules to the System module.

To do:
* [x] Don't unload/reload when enabling/disabling, that's what unload/reload are for
* [x] Optimise the somewhat insane amount of `readdir()`s that this currently does