### PR TITLE
Config storage wip

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -36,4 +36,16 @@ export default class Module {
     return this._enabled
   }
 
+  getOption(name) {
+    return this.options[name]
+  }
+  setOption(name, value) {
+    if (name in this.options) {
+      this.options[name] = value
+    }
+  }
+  getOptions() {
+    return this.options
+  }
+
 }

--- a/src/Module.js
+++ b/src/Module.js
@@ -1,4 +1,5 @@
 const assign = require('object-assign')
+const find = require('array-find')
 
 export default class Module {
 
@@ -36,12 +37,18 @@ export default class Module {
     return this._enabled
   }
 
+  _getOptionName(name) {
+    const names = Object.keys(this.options)
+    const lname = name.toLowerCase()
+    return find(names, n => n.toLowerCase() == lname) || name
+  }
   getOption(name) {
-    return this.options[name]
+    return this.options[this._getOptionName(name)]
   }
   setOption(name, value) {
-    if (name in this.options) {
-      this.options[name] = value
+    const oname = this._getOptionName(name)
+    if (oname in this.options) {
+      this.options[oname] = value
     }
   }
   getOptions() {

--- a/src/modules/Config.module.js
+++ b/src/modules/Config.module.js
@@ -1,0 +1,121 @@
+const SekshiModule = require('../Module')
+const debug = require('debug')('sekshi:config')
+const fs = require('fs')
+const path = require('path')
+const assign = require('object-assign')
+
+export default class Config extends SekshiModule {
+
+  constructor(sekshi, options) {
+    this.author = 'ReAnna'
+    this.version = '1.0.0'
+    this.description = 'Keeps module configuration.'
+
+    super(sekshi, options)
+
+    this.permissions = {
+      set: sekshi.USERROLE.MANAGER,
+      get: sekshi.USERROLE.BOUNCER,
+      loadconfig: sekshi.USERROLE.MANAGER
+    }
+
+    this.onModuleLoaded = this.onModuleLoaded.bind(this)
+  }
+
+  defaultOptions() {
+    return {
+      dir: '../../.config/'
+    }
+  }
+
+  init() {
+    this._createConfigDir()
+
+    this.sekshi.on('moduleloaded', this.onModuleLoaded)
+  }
+  destroy() {
+    this.sekshi.removeListener('moduleloaded', this.onModuleLoaded)
+  }
+
+  onModuleLoaded(mod, name) {
+    // best parameter order?!
+    this._load(name, mod)
+  }
+
+  _dir() {
+    return path.join(__dirname, this.options.dir)
+  }
+  _createConfigDir() {
+    try {
+      fs.statSync(this._dir())
+    }
+    catch (e) {
+      // config dir does not exist
+      try {
+        fs.mkdirSync(this._dir())
+      }
+      catch (e) {
+        debug('mkdir-err', e)
+      }
+    }
+  }
+  _save(ns, mod) {
+    fs.writeFileSync(
+      path.join(this._dir(), `${ns}.json`),
+      // bit of a hack, storing enabled status in config files :"D
+      JSON.stringify(assign(mod.options, { $enabled: mod.enabled() }), null, 2)
+    )
+  }
+  _load(ns, mod) {
+    try {
+      let json = fs.readFileSync(path.join(this._dir(), `${ns}.json`))
+      let config = JSON.parse(json)
+
+      let options = Object.keys(config).filter(opt => opt !== '$enabled')
+      options.forEach(opt => {
+        mod.setOption(opt, config[opt])
+      })
+
+      if (config.$enabled) {
+        mod.enable()
+      }
+    }
+    catch (e) {
+      // default "config"
+      // not quite perfect, possibly!
+      mod.enable()
+    }
+  }
+
+  set(user, ns, option, value) {
+    ns = ns.toLowerCase()
+    let mod = this.sekshi.getModule(ns)
+    if (mod) {
+      if (/^[0-9]+$/.test(value)) value = parseInt(value, 10)
+      debug('value', typeof value, value)
+      mod.setOption(option, value)
+      try {
+        this._save(ns, mod)
+        this.sekshi.sendChat(`@${user.username} "${ns}.${option}" set to ${value}`)
+      }
+      catch (e) {
+        debug('set-err', e)
+        this.sekshi.sendChat(`@${user.username} "${ns}.${option}" was set to ${value}, but could not be saved`)
+      }
+    }
+    else {
+      this.sekshi.sendChat(`@${user.username} Could not find module "${ns}"`)
+    }
+  }
+  get(user, ns, option) {
+    ns = ns.toLowerCase()
+    let mod = this.sekshi.getModule(ns)
+    if (mod) {
+      this.sekshi.sendChat(`@${user.username} "${ns}.${option}": ${mod.getOption(option)}`)
+    }
+    else {
+      this.sekshi.sendChat(`@${user.username} Could not find module "${ns}"`)
+    }
+  }
+
+}

--- a/src/modules/Config.module.js
+++ b/src/modules/Config.module.js
@@ -8,7 +8,7 @@ export default class Config extends SekshiModule {
 
   constructor(sekshi, options) {
     this.author = 'ReAnna'
-    this.version = '1.0.0'
+    this.version = '1.1.0'
     this.description = 'Keeps module configuration.'
 
     super(sekshi, options)
@@ -20,6 +20,7 @@ export default class Config extends SekshiModule {
     }
 
     this.onModuleLoaded = this.onModuleLoaded.bind(this)
+    this.onModuleUnloaded = this.onModuleUnloaded.bind(this)
   }
 
   defaultOptions() {
@@ -32,14 +33,19 @@ export default class Config extends SekshiModule {
     this._createConfigDir()
 
     this.sekshi.on('moduleloaded', this.onModuleLoaded)
+    this.sekshi.on('moduleunloaded', this.onModuleUnloaded)
   }
   destroy() {
     this.sekshi.removeListener('moduleloaded', this.onModuleLoaded)
+    this.sekshi.removeListener('moduleunloaded', this.onModuleUnloaded)
   }
 
   onModuleLoaded(mod, name) {
     // best parameter order?!
-    this._load(name, mod)
+    this._load(name.toLowerCase(), mod)
+  }
+  onModuleUnloaded(mod, name) {
+    this._save(name.toLowerCase(), mod)
   }
 
   _dir() {

--- a/src/sekshi.js
+++ b/src/sekshi.js
@@ -104,10 +104,11 @@ Sekshi.prototype.start = function (credentials) {
     });
 }
 
-Sekshi.prototype.stop = function () {
-    this.unloadModules(this.modulePath);
+Sekshi.prototype.stop = function (cb) {
+    this.unloadModules()
 
-    this.logout(() => {
+    this.logout()
+    this.once(this.LOGOUT_SUCCESS, () => {
         this.removeListener(this.CHAT, this.onMessage);
     });
 }
@@ -323,10 +324,15 @@ Sekshi.prototype._loadModule = function (name) {
     // TODO make configurable
     mod.enable()
 
+    // the event is fired on nextTick so modules can simply listen for "moduleloaded"
+    // and get events for *all* the modules when loadModules() is called, even for those
+    // that register earlier
+    process.nextTick(() => { this.emit('moduleloaded', mod, lName) })
+
     return mod
 }
 
-Sekshi.prototype._unloadModule = function (name) {
+Sekshi.prototype._unloadModule = function (name, fireEvent = true) {
     debug('unload', name)
     const mod = this.getModule(name)
     if (mod) {
@@ -335,4 +341,6 @@ Sekshi.prototype._unloadModule = function (name) {
     const file = this.getModulePath(name)
     delete require.cache[path.resolve(file)]
     delete this.modules[name.toLowerCase()]
+
+    process.nextTick(() => { this.emit('moduleunloaded', mod, name.toLowerCase()) })
 }


### PR DESCRIPTION
Stores the `.options` property of every module in files in a configurable(!) directory.

Adds !get and !set chat commands.
```
!get <modulename> <optionname>
!set <modulename> <optionname> <value>
```

The _loadAll method in [here](https://github.com/welovekpop/SekshiBot/blob/config/src/modules/Config.module.js) is mostly for reading all config at once during startup, but I'm probably going to just batch all "moduleloaded" events towards the end of a Sekshi#loadModules call. That way _load will be called for all available modules, anyway.

TODO:

* [x] Options are only saved when !set is used, so if a module changes its own settings it's out of luck. Maybe save when a module is unloaded, too.