### PR TITLE
rework app.js: get rid of readline-based command line interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "moment": "^2.9.0",
     "mongoose": "*",
     "object-assign": "^2.0.0",
+    "once": "^1.3.1",
     "plugged": "PlugLynn/plugged#edits",
     "promise": "^6.1.0",
     "snoocore": "*",

--- a/src/app.js
+++ b/src/app.js
@@ -1,94 +1,59 @@
-var readline = require("readline");
-var Sekshi = require("./sekshi");
-var config = require('../config.json')
+const Sekshi = require('./sekshi')
+const config = require('../config.json')
 const debug = require('debug')('sekshi:app')
 const pkg = require('../package.json')
+const once = require('once')
 
-var sekshi = new Sekshi(config);
+function start() {
+  const sekshi = new Sekshi(config)
 
-sekshi.start(require("../creds.json"));
+  sekshi.start(require('../creds.json'))
 
-var onError = () => {
-    debug('connection error')
-    setTimeout(() => {
-        debug('reconnecting...')
-    }, 3000)
+  let timeout
+  const onError = once(e => {
+    console.error(e.stack || e)
+    sekshi.stop(() => {
+      console.error('stopped.')
+      process.exit(1)
+    })
+  })
+
+  sekshi.on(sekshi.CONN_ERROR, e => {
+    console.error('connection error')
+    onError(e)
+  })
+  sekshi.on(sekshi.SOCK_ERROR, e => {
+    console.error('connection error')
+    onError(e)
+  })
+  sekshi.on(sekshi.LOGIN_ERROR, e => {
+    console.error('login error')
+    onError(e)
+  })
+
+  sekshi.on(sekshi.CONN_PART, e => {
+    console.error('connection parted')
+    onError(e)
+  })
+
+  sekshi.on(sekshi.CONN_WARNING, warning => {
+    console.warn('connection warning', warning)
+  })
+
+  process.on('uncaughtException', e => {
+    console.error('uncaught exception')
+    onError(e)
+  })
+
+  sekshi.on(sekshi.JOINED_ROOM, err => {
+    if (!err && process.argv[2] !== 'silent') {
+      sekshi.sendChat(`/me SekshiBot v${pkg.version} started!`)
+    }
+    else {
+      console.error('join error')
+      onError(err)
+    }
+  })
 }
-sekshi.on(sekshi.CONN_ERROR, onError)
-sekshi.on(sekshi.LOGIN_ERROR, onError)
-sekshi.on(sekshi.SOCK_ERROR, onError)
 
-sekshi.on(sekshi.CONN_PART, function() {
-    debug("connection parted");
-
-    sekshi.stop();
-    setTimeout(() => {
-        debug('reconnecting...')
-        sekshi.start(require("../creds.json"));
-    }, 3000)
-});
-
-sekshi.on(sekshi.CONN_WARNING, warning => {
-    debug("connection warning", warning)
-});
-
-sekshi.on(sekshi.JOINED_ROOM, err => {
-    if (!err) {
-        sekshi.sendChat('/me SekshiBot v' + pkg.version + ' started!')
-    }
-})
-
-var rl = readline.createInterface(process.stdin, process.stdout);
-
-rl.setPrompt("Sekshi> ");
-rl.prompt();
-
-rl.on("line", function(line) {
-    line = line.split(' ');
-    switch(line.shift()) {
-        case "reloadmodules":
-            sekshi.unloadModules();
-            sekshi.loadModules();
-            break;
-
-        case "unloadmodules":
-            sekshi.unloadModules();
-            break;
-
-        case "loadmodules":
-            sekshi.loadModules();
-            break;
-
-        case "sendchat":
-            sekshi.sendChat(line.join(' '));
-            break;
-
-        case "start":
-            sekshi.start();
-            break;
-
-        case "stop":
-            sekshi.stop();
-            break;
-
-        case "exit":
-            sekshi.stop();
-            process.exit(0);
-            break;
-
-        case "help":
-            console.log("commands:\n\
-                reloadmodules: reloads all modules in module path.\n\
-                unloadmodules: unloads all modules in module path.\n\
-                loadmodules: loads all modules in module path.\n\
-                start: logs the bot in.\n\
-                stop: logs the bot out.\n\
-                exit: stops application.");
-            break;
-
-        default:
-            console.log("unknown command: " + line);
-            break;
-    }
-    rl.prompt();
-});
+start()

--- a/src/sekshi.js
+++ b/src/sekshi.js
@@ -104,12 +104,22 @@ Sekshi.prototype.start = function (credentials) {
     });
 }
 
-Sekshi.prototype.stop = function () {
-    this.unloadModules(this.modulePath);
+Sekshi.prototype.stop = function (cb) {
+    this.unloadModules(this.modulePath)
 
-    this.logout(() => {
-        this.removeListener(this.CHAT, this.onMessage);
-    });
+    this.logout()
+    // should *probably* also wait for this before callback-ing
+    mongoose.disconnect()
+
+    this.once(this.LOGOUT_SUCCESS, () => {
+        this.removeAllListeners()
+        cb()
+    })
+    this.once(this.LOGOUT_ERROR, e => {
+        // might have to close some other stuff here too
+        this.removeAllListeners()
+        cb(e)
+    })
 }
 
 Sekshi.prototype.setDelimiter = function (delimiter) {


### PR DESCRIPTION
Because we didn't use the CLI anyway.

Now shuts down more gracefully, logging errors and everything.
`forever` will restart the process for us, so we can just exit
with a nonzero exit code and all will be well. We won't have
all the prompts anymore in log files either, which is nice.