### PR TITLE
parse and show time stamps as UTC

### DIFF
--- a/src/modules/CheckPlays.module.js
+++ b/src/modules/CheckPlays.module.js
@@ -44,7 +44,7 @@ export default class CheckPlays extends SekshiModule {
   lastplayed() {
     const currentMedia = this.sekshi.getCurrentMedia()
     if (!currentMedia) return
-    const currentStart = moment(this.sekshi.getStartTime(), 'YYYY-MM-DD HH:mm:ss')
+    const currentStart = moment.utc(this.sekshi.getStartTime(), 'YYYY-MM-DD HH:mm:ss')
     Media.findOne({ format: currentMedia.format, cid: currentMedia.cid }).exec().then(
       media => HistoryEntry.findOne({ media: media.id })
                            .where('time').lt(+currentStart)
@@ -70,7 +70,7 @@ export default class CheckPlays extends SekshiModule {
     const since = moment().subtract(hours, 'hours')
     const currentMedia = this.sekshi.getCurrentMedia()
     if (!currentMedia) return
-    const currentStart = moment(this.sekshi.getStartTime(), 'YYYY-MM-DD HH:mm:ss')
+    const currentStart = moment.utc(this.sekshi.getStartTime(), 'YYYY-MM-DD HH:mm:ss')
 
     Media.findOne({ format: currentMedia.format, cid: currentMedia.cid }).exec().then(
       media => HistoryEntry.find({ media: media.id })
@@ -86,7 +86,7 @@ export default class CheckPlays extends SekshiModule {
           const mostRecent = results[results.length - 1]
           const djText = mostRecent.dj ? ` by ${mostRecent.dj.username}` : ''
           this.sekshi.sendChat(`This song was played ${times(playcount)} over the last ${days(hours)}, ` +
-                               `most recently ${moment(mostRecent.time).fromNow()}${djText}.`)
+                               `most recently ${moment(mostRecent.time).utc().fromNow()}${djText}.`)
         }
         else {
           this.sekshi.sendChat(`This song hasn't been played in the last ${days(hours)}.`)

--- a/src/modules/HistoryLogger.module.js
+++ b/src/modules/HistoryLogger.module.js
@@ -2,6 +2,7 @@ const debug = require('debug')('sekshi:history-logging')
 const { User, Media, HistoryEntry } = require('../models')
 const Promise = require('promise')
 const SekshiModule = require('../Module')
+const moment = require('moment')
 
 export default class HistoryLogger extends SekshiModule {
 
@@ -48,13 +49,14 @@ export default class HistoryLogger extends SekshiModule {
       }))
 
     media.then(media => {
+      const startTime = moment.utc(newPlay.startTime, 'YYYY-MM-DD HH:mm:ss')
       debug('media', `${media.fullTitle} (${media.id})`)
-      debug('time', newPlay.startTime)
+      debug('time', startTime.format())
       HistoryEntry.create({
         _id: newPlay.historyID,
         dj: dj.id,
         media: media.id,
-        time: new Date(newPlay.startTime),
+        time: +startTime,
         // heh
         score: { positive: 0, negative: 0, grabs: 0, listeners: 0 }
       })

--- a/src/modules/Roulette.module.js
+++ b/src/modules/Roulette.module.js
@@ -122,7 +122,7 @@ export default class Roulette extends SekshiModule {
     RouletteHistory.findOne({}).select('time').sort({ time: -1 }).exec()
       .then(lastRoulette => {
         if (lastRoulette && lastRoulette.time) {
-          const lastPlayed = moment(lastRoulette.time)
+          const lastPlayed = moment(lastRoulette.time).utc()
           this.sekshi.sendChat(`@${user.username} The last roulette was started ${lastPlayed.calendar()} (${lastPlayed.fromNow()}).`)
         }
         else {


### PR DESCRIPTION
So stuff is more predictable. Also, plug.dj sends timestamps in UTC, but parsing them simply with `moment()` uses the local timezone, so our timing was always off by a few hours. (Especially in !lastplayed and !playcount.)

This fixes all cases where dates are parsed, and where dates are actually shown. In other places the local timezone is used but that doesn't matter!