### PR TITLE
disconnect: automatically return disconnected users to their old position

### DIFF
--- a/src/modules/Disconnect.module.js
+++ b/src/modules/Disconnect.module.js
@@ -12,6 +12,8 @@ const Disconnections = mongoose.modelNames().indexOf('Disconnections') === -1
     })
   : mongoose.model('Disconnections')
 
+const MINUTE = 1000 * 60
+
 export default class Disconnect extends SekshiModule {
   constructor(sekshi, options) {
     super(sekshi, options)
@@ -24,11 +26,13 @@ export default class Disconnect extends SekshiModule {
     this.onWaitlistUpdate = this.onWaitlistUpdate.bind(this)
     this.onWaitlistLock = this.onWaitlistLock.bind(this)
     this.onUserLeave = this.onUserLeave.bind(this)
+    this.onUserJoin = this.onUserJoin.bind(this)
   }
 
   defaultOptions() {
     return {
-      timeLimit: 2 * 60 // minutes
+      timeLimit: 2 * 60, // minutes
+      autodc: false
     }
   }
 
@@ -37,12 +41,14 @@ export default class Disconnect extends SekshiModule {
     this.sekshi.on(this.sekshi.WAITLIST_UPDATE, this.onWaitlistUpdate)
     this.sekshi.on(this.sekshi.DJ_LIST_LOCKED, this.onWaitlistLock)
     this.sekshi.on(this.sekshi.USER_LEAVE, this.onUserLeave)
+    this.sekshi.on(this.sekshi.USER_JOIN, this.onUserJoin)
   }
 
   destroy() {
     this.sekshi.removeListener(this.sekshi.WAITLIST_UPDATE, this.onWaitlistUpdate)
     this.sekshi.removeListener(this.sekshi.DJ_LIST_LOCKED, this.onWaitlistLock)
     this.sekshi.removeListener(this.sekshi.USER_LEAVE, this.onUserLeave)
+    this.sekshi.removeListener(this.sekshi.USER_JOIN, this.onUserJoin)
   }
 
   onWaitlistUpdate(oldWaitlist, newWaitlist) {
@@ -73,6 +79,38 @@ export default class Disconnect extends SekshiModule {
     }
   }
 
+  onUserJoin(user) {
+    if (!this.options.autodc || !user || user.guest) {
+      return
+    }
+    Disconnections.findById(user.id).exec().then(drop => {
+      if (drop && drop.time > Date.now() - this.options.timeLimit * MINUTE) {
+        setTimeout(() => { this.undrop(user, drop) }, 2200)
+      }
+    })
+  }
+
+  undrop(user, drop) {
+    const time = moment(drop.time)
+    this.sekshi.sendChat(`:white_check_mark: @${user.username} disconnected ${time.fromNow()} ` +
+                         `from position ${drop.position + 1}.`)
+
+    const removeDrop = () => {
+      Disconnections.remove({ _id: drop.id }).exec().then(
+        () => { debug('removed drop', drop.id) },
+        e  => { debug('drop remove error', e) }
+      )
+    }
+    if (this.sekshi.getWaitlist().indexOf(drop.id) < 0) {
+      this.sekshi.addToWaitlist(drop.id, () => {
+        this.sekshi.moveDJ(drop.id, drop.position, removeDrop)
+      })
+    }
+    else {
+      this.sekshi.moveDJ(drop.id, drop.position, removeDrop)
+    }
+  }
+
   @command('dc')
   dc(user) {
     debug('!dc', user.username)
@@ -81,28 +119,13 @@ export default class Disconnect extends SekshiModule {
       .then(drop => {
         if (drop) {
           debug('found drop')
-          const time = moment(drop.time)
-          const limit = moment().subtract(this.options.timeLimit, 'minutes')
-          const maxDuration = moment.duration(this.options.timeLimit, 'minutes').humanize()
-          if (time.isBefore(limit)) {
-            this.sekshi.sendChat(`@${user.username} Your last disconnect was too long ago (${time.fromNow(true)}). Disconnects are only valid for ${maxDuration}.`)
-            return
-          }
-          this.sekshi.sendChat(`:white_check_mark: @${user.username} disconnected ${time.fromNow()} ` +
-                               `from position ${drop.position + 1}.`)
-
-          const removeDrop = () => {
-            Disconnections.remove({ _id: drop.id })
-              .then(() => { debug('removed drop', drop.id) })
-              .catch(e => { debug('drop remove error', e) })
-          }
-          if (this.sekshi.getWaitlist().indexOf(drop.id) < 0) {
-            this.sekshi.addToWaitlist(drop.id, () => {
-              this.sekshi.moveDJ(drop.id, drop.position, removeDrop)
-            })
+          if (drop.time > Date.now() - this.options.timeLimit * MINUTE) {
+            this.undrop(user, drop)
           }
           else {
-            this.sekshi.moveDJ(drop.id, drop.position, removeDrop)
+            const timeLimit = moment.duration(this.options.timeLimit, 'minutes').humanize()
+            this.sekshi.sendChat(`@${user.username} Your last disconnect was too long ago. ` +
+                                 `Disconnects are only valid for ${maxDuration}.`)
           }
         }
         else {


### PR DESCRIPTION
Adds an `autodc` option to the Disconnect module, that puts people back in the wait list when they join without needing to type `!dc`.